### PR TITLE
Add progressbar for heavy algorithms

### DIFF
--- a/ext/ClusLogModelExt.jl
+++ b/ext/ClusLogModelExt.jl
@@ -98,7 +98,7 @@ function OnlinePortfolioSelection.cluslog(
   nclusters::Int,
   nclustering::Int,
   boundries::NTuple{2, AbstractFloat};
-  log::Bool=true
+  progress::Bool=true
 )
   nassets, nperiods = size(rel_pr)
   nperiods > horizon || DomainError("horizon must be less than the number of \

--- a/ext/ClusLogModelExt.jl
+++ b/ext/ClusLogModelExt.jl
@@ -150,9 +150,7 @@ function OnlinePortfolioSelection.cluslog(
   return OPSAlgorithm(nassets, b, clus_mod===KmeansModel ? "KMNLOG" : "KMDLOG")
 end
 
-function logger(n::Int)
-  @info "Analysis for trading day $n is done."
-end
+
 
 function cor_between_tws(rel_pr::AbstractMatrix{<:AbstractFloat}, len_tw, ntw)
   nassets = size(rel_pr, 1)

--- a/ext/ClusLogModelExt.jl
+++ b/ext/ClusLogModelExt.jl
@@ -145,7 +145,7 @@ function OnlinePortfolioSelection.cluslog(
         b[:, idx_day]                = optimization(cor_similar_tws, rel_pr_day_after_similar_tws, boundries)
       end
     end
-    log && logger(idx_day)
+    progress && OnlinePortfolioSelection.progressbar(stdout, horizon, idx_day)
   end
   return OPSAlgorithm(nassets, b, clus_mod===KmeansModel ? "KMNLOG" : "KMDLOG")
 end

--- a/src/Algos/CLUSLOG.jl
+++ b/src/Algos/CLUSLOG.jl
@@ -8,7 +8,7 @@
       nclusters::Int,
       nclustering::Int,
       boundries::NTuple{2, AbstractFloat};
-      log::Bool=true
+      progress::Bool=true
     )
 
 You need to install and import the following packages before using this function:
@@ -49,7 +49,7 @@ number of clusters.
 weights of assets in the portfolio.
 
 # Keyword Arguments
-- `log::Bool=true`: Whether to log the progress or not.
+- `progress::Bool=true`: Whether to log the progress or not.
 
 !!! warning "Beware!"
     `rel_pr` should be a matrix of size `n_assets` × `n_periods`.

--- a/src/Algos/CORN.jl
+++ b/src/Algos/CORN.jl
@@ -4,7 +4,8 @@
       horizon::M,
       w::M;
       rho::T=0.2,
-      init_budg=1
+      init_budg=1,
+      progress::Bool=false
     ) where {T<:Float64, M<:Int}
 
 Run CORN-U algorithm.
@@ -17,6 +18,7 @@ Run CORN-U algorithm.
 ## Keyword Arguments
 - `rho::T=0.2`: The correlation coefficient threshold.
 - `init_budg=1`: The initial budget for investment.
+- `progress::Bool=false`: Whether to show the progress bar.
 
 !!! warning "Beware!"
     `adj_close` should be a matrix of size `n_assets` × `n_periods`.
@@ -47,7 +49,8 @@ function cornu(
   horizon::M,
   w::M;
   rho::T=0.2,
-  init_budg=1
+  init_budg=1,
+  progress::Bool=false
 ) where {T<:Float64, M<:Int}
 
   0≤rho<1 || ArgumentError("The value of `rho` should be in the range of [0, 1).") |> throw
@@ -69,7 +72,7 @@ function cornu(
       bₜ[:, ω]    = b
       Sₜ_[ω, t+2] = S(Sₜ_[ω, t+1], b, relative_prices[:, end-horizon+t+1])
     end
-
+    progress && progressbar(stdout, horizon, t+1)
     weights[:, t+1] = final_weights(q, Sₜ_[:, t+2], bₜ)
   end
 
@@ -83,7 +86,8 @@ end
       k::T,
       w::T,
       p::T;
-      init_budg=1
+      init_budg=1,
+      progress::Bool=false
     ) where T<:Int
 
 Run CORN-K algorithm.
@@ -97,6 +101,7 @@ Run CORN-K algorithm.
 
 ## Keyword Arguments
 - `init_budg=1`: The initial budget for investment.
+- `progress::Bool=false`: Whether to show the progress bar.
 
 !!! warning "Beware!"
     `adj_close` should be a matrix of size `n_assets` × `n_periods`.
@@ -128,7 +133,8 @@ function cornk(
   k::T,
   w::T,
   p::T;
-  init_budg=1
+  init_budg=1,
+  progress::Bool=false
 ) where T<:Int
 
   p<2 && ArgumentError("The value of `p` should be more than 1.") |> throw
@@ -161,6 +167,7 @@ function cornk(
 
     idx_top_k       = sortperm(Sₜ_[:, t+2], rev=true)[1:k]
     weights[:, t+1] = final_weights(q, Sₜ_[idx_top_k, t+2], bₜ[:, idx_top_k])
+    progress && progressbar(stdout, horizon, t+1)
   end
 
   return OPSAlgorithm(n_assets, weights, "CORN-K")

--- a/src/Algos/DRICORNK.jl
+++ b/src/Algos/DRICORNK.jl
@@ -7,7 +7,8 @@
       w::M,
       p::M;
       lambda::T=1e-3,
-      init_budg=1
+      init_budg=1,
+      progress::Bool=false
     ) where {T<:Float64, M<:Int}
 
 Run the DRICORNK algorithm.
@@ -23,6 +24,7 @@ Run the DRICORNK algorithm.
 ## Keyword Arguments
 - `lambda::T=1e-3`: The regularization parameter.
 - `init_budg=1`: The initial budget for investment.
+- `progress::Bool=false`: Whether to show the progress bar.
 
 !!! warning "Beware!"
     `adj_close` should be a matrix of size `n_assets` × `n_periods`.
@@ -53,7 +55,8 @@ function dricornk(
   w::M,
   p::M;
   lambda::T=1e-3,
-  init_budg=1
+  init_budg=1,
+  progress::Bool=false
 ) where {T<:Float64, M<:Int}
 
   p<2 && ArgumentError("The value of `p` should be more than 1.") |> throw
@@ -107,6 +110,7 @@ function dricornk(
 
     idx_top_k       = sortperm(Sₜ_[:, t+2], rev=true)[1:k]
     weights[:, t+1] = final_weights(q, Sₜ_[idx_top_k, t+2], bₜ[:, idx_top_k])
+    progress && progressbar(stdout, horizon, t+1)
   end
 
   return OPSAlgorithm(n_assets, weights, "DRICORN-K")

--- a/src/Tools/tools.jl
+++ b/src/Tools/tools.jl
@@ -316,3 +316,13 @@ end
 function bAdjusted(wₜ, relprₜ)
   return (wₜ .* relprₜ)/sum(wₜ .* relprₜ)
 end
+
+function progressbar(io, ntimes::S, current::S) where S<:Int
+  val = current/ntimes
+  val_rounded = round(S, val*10)
+  bars = "████" ^ val_rounded
+  remainder = "    " ^ (10 - val_rounded)
+  joined = bars*remainder
+  percentage = round(val*100, digits=2)
+  printstyled(io, "┣$(joined)┫ $percentage% |$current/$ntimes \r")
+end


### PR DESCRIPTION
Some algorithms such as: `cornk`, `cornu`, `dricorn`, and `cluslog` can be so heavy as the input data gets larger. This can take up to a couple of minutes, and in this case, the user does not have any sense of the situation and what is going on (since nothing is showing up until the code runs successfully). Hence, a progress bar would be beneficial in this case.