### PR TITLE
ClusLog name revision

### DIFF
--- a/docs/src/PM.md
+++ b/docs/src/PM.md
@@ -196,7 +196,7 @@ After intalling the package, you can use the [`cluslog`](@ref) function after im
 ```julia
 julia> using OnlinePortfolioSelection, Clustering
 
-julia> horizon, max_window_size, clustering_model, max_n_clusters, max_n_clustering, optm_boundries = 2, 3, KMNModel, 3, 7, (0.0, 1.0);
+julia> horizon, max_window_size, clustering_model, max_n_clusters, max_n_clustering, optm_boundries = 2, 3, KMNLOG, 3, 7, (0.0, 1.0);
 
 julia> prices = prices |> permutedims;
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -90,7 +90,7 @@ Run MRvol algorithm.
 
 # Run [ClusLog](@ref) Algorithm
 
-Another example can be using [`cluslog`](@ref) function to perform 'KMNLOG' or 'KMDLOG' model (see [ClusLog](@ref), [`KMNModel`](@ref), and [`KMDModel`](@ref) for more details):
+Another example can be using [`cluslog`](@ref) function to perform 'KMNLOG' or 'KMDLOG' model (see [ClusLog](@ref), [`KMNLOG`](@ref), and [`KMDLOG`](@ref) for more details):
 
 ```python
 # before running the following code, please read the
@@ -105,7 +105,7 @@ Another example can be using [`cluslog`](@ref) function to perform 'KMNLOG' or '
 
 >>> import numpy as np
 >>> rel_pr = np.random.rand(3, 150)
->>> horizon, max_tw_len, clustering_model = 50, 10, OPS.KMNModel
+>>> horizon, max_tw_len, clustering_model = 50, 10, OPS.KMNLOG
 >>> max_n_clus, max_n_clustering, asset_bounderies = 10, 10, (0., 1.)
 >>> model = OPS.cluslog(rel_pr, horizon, max_tw_len, clustering_model, max_n_clus, max_n_clustering, asset_bounderies)
 █████████████████████████████████████┫ 100.0% |50/50

--- a/src/Algos/CLUSLOG.jl
+++ b/src/Algos/CLUSLOG.jl
@@ -4,7 +4,7 @@
       rel_pr::AbstractMatrix{<:AbstractFloat},
       horizon::Int,
       TW::Int,
-      clus_mod::Type{<:ClusteringModel},
+      clus_mod::Type{<:ClusLogVariant},
       nclusters::Int,
       nclustering::Int,
       boundries::NTuple{2, AbstractFloat};
@@ -26,7 +26,7 @@ julia> using OnlinePortfolioSelection, Clustering
       rel_pr::AbstractMatrix{<:AbstractFloat},
       horizon::Int,
       TW::Int,
-      clus_mod::Type{<:ClusteringModel},
+      clus_mod::Type{<:ClusLogVariant},
       nclusters::Int,
       nclustering::Int,
       boundries::NTuple{2, AbstractFloat};
@@ -40,8 +40,8 @@ Run KMNLOG, KMDLOG, etc., algorithms on the given data.
 represents the price of an asset at a given time.
 - `horizon::Int`: Number of trading days.
 - `TW::Int`: Maximum time window length to be examined.
-- `clus_mod::Type{<:ClusteringModel}`: Clustering model to be used. Currently, only \
-[`KMNModel`](@ref) and [`KMDModel`](@ref) are supported.
+- `clus_mod::Type{<:ClusLogVariant}`: Clustering model to be used. Currently, only \
+[`KMNLOG`](@ref) and [`KMDLOG`](@ref) are supported.
 - `nclusters::Int`: The maximum number of clusters to be examined.
 - `nclustering::Int`: The number of times clustering algorithm is run for optimal \
 number of clusters.
@@ -58,8 +58,8 @@ weights of assets in the portfolio.
 - `::OPSAlgorithm`: An [`OPSAlgorithm`](@ref) object.
 
 # Example
-Two clustering model is available as of now: [`KMNModel`](@ref), and [`KMDModel`](@ref). \
-The first example utilizes [`KMNModel`](@ref):
+Two clustering model is available as of now: [`KMNLOG`](@ref), and [`KMDLOG`](@ref). \
+The first example utilizes [`KMNLOG`](@ref):
 
 ```julia
 julia> using OnlinePortfolioSelection, Clustering
@@ -74,7 +74,7 @@ julia> rel_pr = adj_close[:, 2:end]./adj_close[:, 1:end-1]
 
 julia> horizon = 3; TW = 3; nclusters_ = 3; nclustering = 10; lb, ub = 0.0, 1.;
 
-julia> model = cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (lb, ub));
+julia> model = cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (lb, ub));
 
 julia> model.b
 3×3 Matrix{Float64}:
@@ -86,12 +86,12 @@ julia> sum(model.b , dims=1) .|> isapprox(1.) |> all
 true
 ```
 
-The same approach works for [`KMDModel`](@ref) as well:
+The same approach works for [`KMDLOG`](@ref) as well:
 
 ```julia
 julia> using OnlinePortfolioSelection, Clustering
 
-julia> model = cluslog(rel_pr, horizon, TW, KMDModel, nclusters_, nclustering, (lb, ub));
+julia> model = cluslog(rel_pr, horizon, TW, KMDLOG, nclusters_, nclustering, (lb, ub));
 
 julia> model.b
 3×3 Matrix{Float64}:
@@ -103,7 +103,7 @@ julia> sum(model.b , dims=1) .|> isapprox(1.) |> all
 true
 ```
 
-See also [`KMNModel`](@ref), and [`KMDModel`](@ref).
+See also [`KMNLOG`](@ref), and [`KMDLOG`](@ref).
 
 # Reference
 > [An online portfolio selection algorithm using clustering approaches and considering transaction costs](https://doi.org/10.1016/j.eswa.2020.113546)

--- a/src/OnlinePortfolioSelection.jl
+++ b/src/OnlinePortfolioSelection.jl
@@ -35,7 +35,7 @@ include("Tools/cornfam.jl")
 export up, eg, cornu, cornk, dricornk, crp, bs, rprt, anticor, olmar, bk, load, mrvol, cwogd
 export uniform, cluslog, pamr
 export OPSMetrics, sn, mer, apy, ann_std, ann_sharpe, mdd, calmar
-export OPSAlgorithm, KMNModel, KMDModel, ClusteringModel, PAMR, PAMR1, PAMR2
+export OPSAlgorithm, KMNLOG, KMDLOG, ClusLogVariant, PAMR, PAMR1, PAMR2
 export opsmethods
 
 @setup_workload begin

--- a/src/Types/Clustering.jl
+++ b/src/Types/Clustering.jl
@@ -1,31 +1,15 @@
-abstract type ClusteringModel end
+abstract type ClusLogVariant end
 
 """
-    KMNModel(alg::String="KMNLOG")<:ClusteringModel
+    KMNLOG(alg::String="KMNLOG")<:ClusLogVariant
 
-`KMNModel` is a concrete type used to represent the KMNLOG Model. Also, see [`KMDModel`](@ref).
-
-# Fields
-- `alg::String="KMNLOG"`: The algorithm's name to be used.
-
-!!! warning
-    Do not try to change the value of `alg` field.
+`KMNLOG` is a concrete type used to represent the KMNLOG Model. Also, see [`KMDLOG`](@ref).
 """
-@kwdef struct KMNModel<:ClusteringModel
-  alg::String="KMNLOG"
-end
+struct KMNLOG<:ClusLogVariant end
 
 """
-    KMDModel(alg::String="KMDLOG")<:ClusteringModel
+    KMDLOG(alg::String="KMDLOG")<:ClusLogVariant
 
-`KMDModel` is a concrete type used to represent the KMDLOG Model. Also, see [`KMNModel`](@ref).
-
-# Fields
-- `alg::String="KMDLOG"`: The algorithm's name to be used.
-
-!!! warning
-    Do not try to change the value of `alg` field.
+`KMDLOG` is a concrete type used to represent the KMDLOG Model. Also, see [`KMNLOG`](@ref).
 """
-@kwdef struct KMDModel<:ClusteringModel
-  alg::String="KMDLOG"
-end
+struct KMDLOG<:ClusLogVariant end

--- a/test/CLUSLOG.jl
+++ b/test/CLUSLOG.jl
@@ -23,18 +23,18 @@ lb, ub = 0., 1.
 
 @testset "CLUSLOG.jl" begin
   @testset "With valid args" begin
-    model = cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (lb, ub))
+    model = cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (lb, ub))
     @test model.alg == "KMNLOG"
     @test sum(model.b, dims=1) .|> isapprox(1.) |> all
     @test size(model.b) == (nassets, horizon)
 
-    model = cluslog(rel_pr, horizon, TW, KMDModel, nclusters_, nclustering, (lb, ub))
+    model = cluslog(rel_pr, horizon, TW, KMDLOG, nclusters_, nclustering, (lb, ub))
     @test model.alg == "KMDLOG"
     @test sum(model.b, dims=1) .|> isapprox(1.) |> all
     @test size(model.b) == (nassets, horizon)
 
     # Intended for testing the algorithm if there is no similar time windows found at the first day
-    model = cluslog(rel_pr2, horizon, TW, KMDModel, nclusters_, nclustering, (lb, ub))
+    model = cluslog(rel_pr2, horizon, TW, KMDLOG, nclusters_, nclustering, (lb, ub))
     @test model.alg == "KMDLOG"
     @test sum(model.b, dims=1) .|> isapprox(1.) |> all
     @test size(model.b) == (nassets, horizon)
@@ -46,17 +46,17 @@ lb, ub = 0., 1.
   end
 
   @testset "With invalid args" begin
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, 1, nclustering, (lb, ub)) # nclusters≥2
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, 0, (lb, ub)) # nclustering≥1
-    @test_throws DomainError cluslog(rel_pr, horizon, 1, KMNModel, nclusters_, nclustering, (lb, ub)) # TW≥2
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (ub, lb)) # ub > lb
-    @test_throws DomainError cluslog(rel_pr, 0, TW, KMNModel, nclusters_, nclustering, (lb, ub)) # horizon>0
-    @test_throws MethodError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (lb, ub, 1.)) # length(boundries)==2
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, 8, nclustering, (lb, ub)) # nclusters ≤ nperiods-horizon
-    @test_throws DomainError cluslog(rel_pr, horizon, 8, KMNModel, nclusters_, nclustering, (lb, ub)) # TW < nperiods-horizon+1
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (0.34, ub)) # boundries[1] < 1/nassets
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (-0.1, ub)) # lb>0
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (lb, -0.1)) # 0<ub≤1
-    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNModel, nclusters_, nclustering, (lb, 1.1)) # 0<ub≤1
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, 1, nclustering, (lb, ub)) # nclusters≥2
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, 0, (lb, ub)) # nclustering≥1
+    @test_throws DomainError cluslog(rel_pr, horizon, 1, KMNLOG, nclusters_, nclustering, (lb, ub)) # TW≥2
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (ub, lb)) # ub > lb
+    @test_throws DomainError cluslog(rel_pr, 0, TW, KMNLOG, nclusters_, nclustering, (lb, ub)) # horizon>0
+    @test_throws MethodError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (lb, ub, 1.)) # length(boundries)==2
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, 8, nclustering, (lb, ub)) # nclusters ≤ nperiods-horizon
+    @test_throws DomainError cluslog(rel_pr, horizon, 8, KMNLOG, nclusters_, nclustering, (lb, ub)) # TW < nperiods-horizon+1
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (0.34, ub)) # boundries[1] < 1/nassets
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (-0.1, ub)) # lb>0
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (lb, -0.1)) # 0<ub≤1
+    @test_throws DomainError cluslog(rel_pr, horizon, TW, KMNLOG, nclusters_, nclustering, (lb, 1.1)) # 0<ub≤1
   end
 end


### PR DESCRIPTION
This PR is due to making consistency between the package and the paper. Formerly, I have used `KMNModel` and `KMDModel` to represent `KMNLOG` and `KMDLOG` variants, respectively, that were not aligned with the paper's terminology.