### PR TITLE
`load` now only returns `OPSAlgorithm` 🔧

### DIFF
--- a/docs/src/Combined.md
+++ b/docs/src/Combined.md
@@ -27,7 +27,7 @@ julia> prices = prices |> permutedims;
 
 julia> d_fac, window, horizon, eta = 0.5, 10, 5, 0.1;
 
-julia> model, St = load(prices, d_fac, window, horizon, eta);
+julia> model = load(prices, d_fac, window, horizon, eta);
 
 # Get the portfolio weights
 julia> model.b
@@ -35,16 +35,6 @@ julia> model.b
  0.333333  2.65043e-10  1.65697e-8  0.669392  0.329286
  0.333333  1.0          1.0         0.330608  0.670714
  0.333333  0.0          0.0         0.0       0.0 
-
-# Get the cumulative wealth of the portfolio over the trading period
-julia> St
-6-element Vector{Float64}:
- 1.0
- 0.9937811173943497
- 0.9925654837139548
- 0.9787063658040356
- 0.9652327928615669
- 1.012107319760618
 ```
 
 The result indicates that if we had invested in the given period, we would have gained ~1.2% profit. Now, let's investiagte the performance of the algorithm according to some of the prominent metrics:

--- a/src/Algos/LOAD.jl
+++ b/src/Algos/LOAD.jl
@@ -213,13 +213,11 @@ function load(adj_close::AbstractMatrix{T}, α::T, ω::S, horizon::S, η::T; ϵ:
   number of training period. Either provide more data or decrease the value of `ω` or \
   decrease the `horizon` value") |> throw
 
-  Sₜ = ones(T, horizon+1)
   rel_pr = adj_close[:, 2:end] ./ adj_close[:, 1:end-1]
   b = ones(T, n_assets, horizon)/n_assets
   for t ∈ 1:horizon
     bₜ = b[:, t]
     train = adj_close[:, end-horizon+t-ω:end-horizon+t-1]
-    Sₜ[t+1] = sₜ(Sₜ[t], bₜ, rel_pr[:, end-horizon+t])
     aᵢ = fᵢ(train)
     p̂ₜ₊₁ = predict(η, aᵢ, train, α)
     pr_rel = next_pr_rel(adj_close[:, end-horizon+t-1], p̂ₜ₊₁)
@@ -231,5 +229,5 @@ function load(adj_close::AbstractMatrix{T}, α::T, ω::S, horizon::S, η::T; ϵ:
     b[:, t+1] = max.(b[:, t+1], 0)
     normalizer!(b, t+1)
   end
-  return OPSAlgorithm(n_assets, b, "LOAD"), Sₜ
+  return OPSAlgorithm(n_assets, b, "LOAD")
 end

--- a/test/LOAD.jl
+++ b/test/LOAD.jl
@@ -7,7 +7,7 @@ adj_close = [
 
 @testset "LOAD.jl" begin
   @testset "with valid arguments" begin
-    m_load, s = load(adj_close, 0.1, 3, 3, 0.5)
+    m_load = load(adj_close, 0.1, 3, 3, 0.5)
 
     @test sum(m_load.b, dims=1) .|> isapprox(1.0) |> all
 
@@ -15,7 +15,7 @@ adj_close = [
   end
 
   @testset "with high η" begin
-    m_load, s = load(adj_close, 0.1, 3, 3, 5.)
+    m_load = load(adj_close, 0.1, 3, 3, 5.)
 
     @test sum(m_load.b, dims=1) .|> isapprox(1.0) |> all
 


### PR DESCRIPTION
This change is due to consistency with the package's API. As I stated, all algorithms return an object of `OPSAlgorithm` that was not consistent with the `load` implementation. Due to this change, `load` only returns the object and nothing else.