### PR TITLE
Avoid calling `maximum(...; dims)` with empty arrays

### DIFF
--- a/src/Algos/TPPT.jl
+++ b/src/Algos/TPPT.jl
@@ -43,7 +43,9 @@ function p̂ₜ₊₁func(kₜ::AbstractMatrix, p::AbstractMatrix, w::Integer, �
   idx_under_zero        = vec(sum(kₜ, dims=2)).<0.
   idx_equal_zero        = vec(sum(kₜ, dims=2)).==0.
   p̂ₜ₊₁                  = similar(kₜ, n_assets)
-  p̂ₜ₊₁[idx_under_zero] .= maximum(p[idx_under_zero, :], dims=2)
+  if any(idx_under_zero)
+    p̂ₜ₊₁[idx_under_zero] .= maximum(p[idx_under_zero, :], dims=2)
+  end
   p̂ₜ₊₁[idx_equal_zero] .= p[idx_equal_zero, end]
   p̂ₜ₊₁[idx_over_zero]  .= sum(α*(1-α)^(w-i) *p[idx_over_zero, w-i] for i=0:w-1)
   return p̂ₜ₊₁


### PR DESCRIPTION
There's a proposed "minor change" to Julia v1.13 that would make `maximum([], dims=2)` (and other such reductions) an error, akin to how `maximum([])` is an error when `init` is not specified.  This package was flagged as having (at least) one such usage here; it errored in [PkgEval](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/813bcf3_vs_c3e7b1b/report.html).  See https://github.com/JuliaLang/julia/pull/55628 for more details.